### PR TITLE
PZ2D-3535 WeightRange.minimum change to string as workaround until Amazon fix "minimum":"$weightRange.minimum"

### DIFF
--- a/models/fulfillment-inbound-api-model/fulfillmentInbound_2024-03-20.json
+++ b/models/fulfillment-inbound-api-model/fulfillmentInbound_2024-03-20.json
@@ -14932,7 +14932,7 @@
           "description": "Minimum allowed weight.",
           "maximum": 100000,
           "minimum": 0,
-          "type": "number"
+          "type": "string"
         },
         "unit": {
           "$ref": "#/definitions/UnitOfWeight"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
